### PR TITLE
Add armv327 multiarch support

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,0 +1,70 @@
+FROM debian:buster AS builder
+
+# Download QEMU, see https://github.com/docker/hub-feedback/issues/1261
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    apt-utils \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt -qyy clean
+RUN export QEMU_USER_STATIC_LATEST_TAG=$(curl -s https://api.github.com/repos/multiarch/qemu-user-static/tags \
+        | grep 'name.*v[0-9]' | head -n 1 | cut -d '"' -f 4) && \
+    curl -SL "https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_USER_STATIC_LATEST_TAG}/x86_64_qemu-arm-static.tar.gz" \
+        | tar xzv --directory /
+
+FROM --platform="linux/arm/v7" golang:1.13-alpine AS go-builder
+
+COPY --from=builder /qemu-arm-static /usr/bin/
+
+ENV DOCKER_GEN_VERSION=0.7.4
+
+# Install build dependencies for docker-gen
+RUN apk add --update \
+        curl \
+        gcc \
+        git \
+        make \
+        musl-dev
+
+# Build docker-gen
+RUN go get github.com/jwilder/docker-gen \
+    && cd /go/src/github.com/jwilder/docker-gen \
+    && git checkout $DOCKER_GEN_VERSION \
+    && make get-deps \
+    && make all
+
+FROM --platform="linux/arm/v7" alpine:3.10
+
+COPY --from=builder /qemu-arm-static /usr/bin/
+
+LABEL maintainer="Yves Blusseau <90z7oey02@sneakemail.com> (@blusseau)"
+
+ENV DEBUG=false \
+    DOCKER_HOST=unix:///var/run/docker.sock
+
+# Install packages required by the image
+RUN apk add --update \
+        bash \
+        ca-certificates \
+        coreutils \
+        curl \
+        jq \
+        openssl \
+    && rm /var/cache/apk/*
+
+# Install docker-gen from build stage
+COPY --from=go-builder /go/src/github.com/jwilder/docker-gen/docker-gen /usr/local/bin/
+
+# Install simp_le
+COPY /install_simp_le.sh /app/install_simp_le.sh
+RUN chmod +rx /app/install_simp_le.sh \
+    && sync \
+    && /app/install_simp_le.sh \
+    && rm -f /app/install_simp_le.sh
+
+COPY /app/ /app/
+
+WORKDIR /app
+
+ENTRYPOINT [ "/bin/bash", "/app/entrypoint.sh" ]
+CMD [ "/bin/bash", "/app/start.sh" ]

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Use manifest-tool to create the manifest, given the experimental
+# "docker manifest" command isn't available yet on Docker Hub.
+
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v0.9.0/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+./manifest-tool push from-spec multi-arch-manifest.yaml

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Register qemu-*-static for all supported processors except the 
+# current one, but also remove all registered binfmt_misc before
+docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/multi-arch-manifest.yaml
+++ b/multi-arch-manifest.yaml
@@ -1,0 +1,11 @@
+image: jrcs/letsencrypt-nginx-proxy-companion:latest
+manifests:
+  - image: jrcs/letsencrypt-nginx-proxy-companion:amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: jrcs/letsencrypt-nginx-proxy-companion:arm32v7
+    platform:
+      architecture: arm
+      os: linux
+      variant: v7


### PR DESCRIPTION
Continuation of #/564

Note: Don't merge yet, because Dockerhub does not support the ``--platform`` flag yet. It will work locally.

1. You will need to update dockerhub to build the current latest build to a new tag which is amd64
2. Create a new arm32v7 tag which would build the new ``Dockerfile.arm32v7`` (sadly this creates repetition, but this is the only way I know minus sharing a script between dockerfiles, which has its own level of suckness).
3. You will have to remove the current latest tag and then let the hooks in the hooks folder create a new latest tag, using the manifest command.

A working example can be seen here:
https://cloud.docker.com/repository/docker/guysoft/letsencrypt-nginx-proxy-companion

