### PR TITLE
Implemented LETSENCRYPT_STANDALONE_CERTS support from container env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ nginx.tmpl
 test/local_test_env.sh
 test/tests/docker_api/expected-std-out.txt
 test/tests/container_restart/docker_event_out.txt
+test/tests/certs_standalone/letsencrypt_user_data

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -160,6 +160,7 @@ if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
     check_writable_directory '/etc/nginx/certs'
     check_writable_directory '/etc/nginx/vhost.d'
     check_writable_directory '/usr/share/nginx/html'
+    [[ -f /app/letsencrypt_user_data ]] && check_writable_directory '/etc/nginx/conf.d'
     check_deprecated_env_var
     check_default_cert_key
     check_dh_group

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -49,6 +49,8 @@ function create_links {
 }
 
 function cleanup_links {
+    local -a LETSENCRYPT_CONTAINERS
+    local -a LETSENCRYPT_STANDALONE_CERTS
     local -a ENABLED_DOMAINS
     local -a SYMLINKED_DOMAINS
     local -a DISABLED_DOMAINS
@@ -64,9 +66,10 @@ function cleanup_links {
     [[ "$(lc $DEBUG)" == true ]] && echo "Symlinked domains: ${SYMLINKED_DOMAINS[*]}"
 
     # Create an array containing domains that are considered
-    # enabled (ie present on /app/letsencrypt_service_data).
-    # shellcheck source=/dev/null
-    source /app/letsencrypt_service_data
+    # enabled (ie present on /app/letsencrypt_service_data or /app/letsencrypt_user_data).
+    [[ -f /app/letsencrypt_service_data ]] && source /app/letsencrypt_service_data
+    [[ -f /app/letsencrypt_user_data ]] && source /app/letsencrypt_user_data
+    LETSENCRYPT_CONTAINERS+=( "${LETSENCRYPT_STANDALONE_CERTS[@]}" )
     for cid in "${LETSENCRYPT_CONTAINERS[@]}"; do
       host_varname="LETSENCRYPT_${cid}_HOST"
       hosts_array="${host_varname}[@]"
@@ -79,7 +82,7 @@ function cleanup_links {
 
     # Create an array containing only domains for which a symlinked private key exists
     # in /etc/nginx/certs but that no longer have a corresponding LETSENCRYPT_HOST set
-    # on an active container.
+    # on an active container or on /app/letsencrypt_user_data
     if [[ ${#SYMLINKED_DOMAINS[@]} -gt 0 ]]; then
         mapfile -t DISABLED_DOMAINS < <(echo "${SYMLINKED_DOMAINS[@]}" \
                                              "${ENABLED_DOMAINS[@]}" \
@@ -119,15 +122,34 @@ function cleanup_links {
 }
 
 function update_certs {
+    local -a LETSENCRYPT_CONTAINERS
+    local -a LETSENCRYPT_STANDALONE_CERTS
 
     check_nginx_proxy_container_run || return
 
-    [[ -f /app/letsencrypt_service_data ]] || return
-
     # Load relevant container settings
-    unset LETSENCRYPT_CONTAINERS
-    # shellcheck source=/dev/null
-    source /app/letsencrypt_service_data
+    if [[ -f /app/letsencrypt_service_data ]]; then
+        source /app/letsencrypt_service_data
+    else
+        echo "Warning: /app/letsencrypt_service_data not found, skipping data from containers."
+    fi
+
+    # Load settings for standalone certs
+    if [[ -f /app/letsencrypt_user_data ]]; then
+        if source /app/letsencrypt_user_data; then
+            for cid in "${LETSENCRYPT_STANDALONE_CERTS[@]}"; do
+                host_varname="LETSENCRYPT_${cid}_HOST"
+                hosts_array="${host_varname}[@]"
+                for domain in "${!hosts_array}"; do
+                    add_standalone_configuration "$domain"
+                done
+            done
+            reload_nginx
+            LETSENCRYPT_CONTAINERS+=( "${LETSENCRYPT_STANDALONE_CERTS[@]}" )
+        else
+            echo "Warning: could not source /app/letsencrypt_user_data, skipping user data"
+        fi
+    fi
 
     should_reload_nginx='false'
     for cid in "${LETSENCRYPT_CONTAINERS[@]}"; do
@@ -144,7 +166,7 @@ function update_certs {
 
         # Use container's LETSENCRYPT_EMAIL if set, fallback to DEFAULT_EMAIL
         email_varname="LETSENCRYPT_${cid}_EMAIL"
-        email_address="${!email_varname}"
+        email_address="${!email_varname:-"<no value>"}"
         if [[ "$email_address" != "<no value>" ]]; then
             params_d_str+=" --email $email_address"
         elif [[ -n "${DEFAULT_EMAIL:-}" ]]; then
@@ -152,7 +174,7 @@ function update_certs {
         fi
 
         keysize_varname="LETSENCRYPT_${cid}_KEYSIZE"
-        cert_keysize="${!keysize_varname}"
+        cert_keysize="${!keysize_varname:-"<no value>"}"
         if [[ "$cert_keysize" == "<no value>" ]]; then
             cert_keysize=$DEFAULT_KEY_SIZE
         fi
@@ -172,7 +194,7 @@ function update_certs {
         fi
 
         account_varname="LETSENCRYPT_${cid}_ACCOUNT_ALIAS"
-        account_alias="${!account_varname}"
+        account_alias="${!account_varname:-"<no value>"}"
         if [[ "$account_alias" == "<no value>" ]]; then
             account_alias=default
         fi
@@ -181,7 +203,7 @@ function update_certs {
         [[ $REUSE_PRIVATE_KEYS == true ]] && params_d_str+=" --reuse_key"
 
         min_validity="LETSENCRYPT_${cid}_MIN_VALIDITY"
-        min_validity="${!min_validity}"
+        min_validity="${!min_validity:-"<no value>"}"
         if [[ "$min_validity" == "<no value>" ]]; then
             min_validity=$DEFAULT_MIN_VALIDITY
         fi
@@ -308,6 +330,13 @@ function update_certs {
             echo "Restarting container (${cid})..."
             docker_restart "${cid}"
         fi
+
+        for domain in "${!hosts_array}"; do
+            if [[ -f "/etc/nginx/conf.d/standalone-cert-$domain.conf" ]]; then
+                [[ $DEBUG == true ]] && echo "Debug: removing standalone configuration file /etc/nginx/conf.d/standalone-cert-$domain.conf"
+                rm -f "/etc/nginx/conf.d/standalone-cert-$domain.conf" && should_reload_nginx='true'
+            fi
+        done
 
     done
 

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -1,10 +1,22 @@
-LETSENCRYPT_CONTAINERS=({{ range $hosts, $containers := groupBy $ "Env.LETSENCRYPT_HOST" }}{{ if trim $hosts }}{{ range $container := $containers }} '{{ printf "%.12s" $container.ID }}' {{ end }}{{ end }}{{ end }})
+LETSENCRYPT_CONTAINERS=({{ range $hosts, $containers := groupBy $ "Env.LETSENCRYPT_HOST" }}{{ if trim $hosts }}{{ range $container := $containers }}{{ if ($container.Env.LETSENCRYPT_STANDALONE_CERTS) and eq $container.Env.LETSENCRYPT_STANDALONE_CERTS "true" }}{{ range $host := split $hosts "," }}{{ $host := trim $host }}'{{ printf "%.12s" $container.ID }}_{{ sha1 $host }}' {{ end }}{{ else }}'{{ printf "%.12s" $container.ID }}' {{ end }}{{ end }}{{ end }}{{ end }})
 
 {{ range $hosts, $containers := groupBy $ "Env.LETSENCRYPT_HOST" }}
-
 {{ $hosts := trimSuffix "," $hosts }}
-
-{{ range $container := $containers }}{{ $cid := printf "%.12s" $container.ID }}
+{{ range $container := $containers }}
+{{ $cid := printf "%.12s" $container.ID }}
+{{ if ($container.Env.LETSENCRYPT_STANDALONE_CERTS) and eq $container.Env.LETSENCRYPT_STANDALONE_CERTS "true" }}
+{{ range $host := split $hosts "," }}
+{{ $host := trim $host }}
+{{ $hostHash := sha1 $host }}
+LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_HOST=('{{ $host }}')
+LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_EMAIL="{{ $container.Env.LETSENCRYPT_EMAIL }}"
+LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_KEYSIZE="{{ $container.Env.LETSENCRYPT_KEYSIZE }}"
+LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_TEST="{{ $container.Env.LETSENCRYPT_TEST }}"
+LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_ACCOUNT_ALIAS="{{ $container.Env.LETSENCRYPT_ACCOUNT_ALIAS }}"
+LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_RESTART_CONTAINER="{{ $container.Env.LETSENCRYPT_RESTART_CONTAINER }}"
+LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_MIN_VALIDITY="{{ $container.Env.LETSENCRYPT_MIN_VALIDITY }}"
+{{ end }}
+{{ else }}
 LETSENCRYPT_{{ $cid }}_HOST=( {{ range $host := split $hosts "," }}{{ $host := trim $host }}'{{ $host }}' {{ end }})
 LETSENCRYPT_{{ $cid }}_EMAIL="{{ $container.Env.LETSENCRYPT_EMAIL }}"
 LETSENCRYPT_{{ $cid }}_KEYSIZE="{{ $container.Env.LETSENCRYPT_KEYSIZE }}"
@@ -13,5 +25,5 @@ LETSENCRYPT_{{ $cid }}_ACCOUNT_ALIAS="{{ $container.Env.LETSENCRYPT_ACCOUNT_ALIA
 LETSENCRYPT_{{ $cid }}_RESTART_CONTAINER="{{ $container.Env.LETSENCRYPT_RESTART_CONTAINER }}"
 LETSENCRYPT_{{ $cid }}_MIN_VALIDITY="{{ $container.Env.LETSENCRYPT_MIN_VALIDITY }}"
 {{ end }}
-
+{{ end }}
 {{ end }}

--- a/app/start.sh
+++ b/app/start.sh
@@ -7,6 +7,7 @@ term_handler() {
 
     source /app/functions.sh
     remove_all_location_configurations
+    remove_all_standalone_configurations
 
     exit 0
 }

--- a/test/config.sh
+++ b/test/config.sh
@@ -12,6 +12,7 @@ imageTests+=(
 	default_cert
 	certs_single
 	certs_san
+	certs_standalone
 	force_renew
 	certs_validity
 	container_restart

--- a/test/config.sh
+++ b/test/config.sh
@@ -13,6 +13,7 @@ imageTests+=(
 	certs_single
 	certs_san
 	certs_standalone
+	certs_standalone_from_env
 	force_renew
 	certs_validity
 	container_restart

--- a/test/setup/setup-nginx-proxy.sh
+++ b/test/setup/setup-nginx-proxy.sh
@@ -9,6 +9,7 @@ case $SETUP in
       --name $NGINX_CONTAINER_NAME \
       --env "DHPARAM_BITS=256" \
       -v /etc/nginx/vhost.d \
+      -v /etc/nginx/conf.d \
       -v /usr/share/nginx/html \
       -v /var/run/docker.sock:/tmp/docker.sock:ro \
       --label com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite \

--- a/test/tests/certs_standalone/expected-std-out.txt
+++ b/test/tests/certs_standalone/expected-std-out.txt
@@ -1,0 +1,8 @@
+Started letsencrypt container for test certs_standalone
+Symlink to le1.wtf certificate has been generated.
+The link is pointing to the file ./le1.wtf/fullchain.pem
+Domain le1.wtf is on certificate.
+Symlink to le2.wtf certificate has been generated.
+The link is pointing to the file ./le2.wtf/fullchain.pem
+Domain le2.wtf is on certificate.
+Domain le3.wtf is on certificate.

--- a/test/tests/certs_standalone/run.sh
+++ b/test/tests/certs_standalone/run.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+## Test for standalone certificates.
+
+if [[ -z $TRAVIS_CI ]]; then
+  le_container_name="$(basename ${0%/*})_$(date "+%Y-%m-%d_%H.%M.%S")"
+else
+  le_container_name="$(basename ${0%/*})"
+fi
+
+# Create the $domains array from comma separated domains in TEST_DOMAINS.
+IFS=',' read -r -a domains <<< "$TEST_DOMAINS"
+
+# Cleanup function with EXIT trap
+function cleanup {
+  # Cleanup the files created by this run of the test to avoid foiling following test(s).
+  docker exec "$le_container_name" bash -c 'rm -rf /etc/nginx/certs/le?.wtf*'
+  # Stop the LE container
+  docker stop "$le_container_name" > /dev/null
+}
+trap cleanup EXIT
+
+# Create letsencrypt_user_data with a single domain cert
+cat > ${TRAVIS_BUILD_DIR}/test/tests/certs_standalone/letsencrypt_user_data <<EOF
+LETSENCRYPT_STANDALONE_CERTS=('single')
+LETSENCRYPT_single_HOST=('${domains[0]}')
+EOF
+
+run_le_container ${1:?} "$le_container_name" \
+  "--volume ${TRAVIS_BUILD_DIR}/test/tests/certs_standalone/letsencrypt_user_data:/app/letsencrypt_user_data"
+
+# Wait for a symlink at /etc/nginx/certs/${domains[0]}.crt
+# then grab the certificate in text form ...
+wait_for_symlink "${domains[0]}" "$le_container_name"
+created_cert="$(docker exec "$le_container_name" \
+  openssl x509 -in /etc/nginx/certs/${domains[0]}/cert.pem -text -noout)"
+
+# Check if the domain is on the certificate.
+if grep -q "${domains[0]}" <<< "$created_cert"; then
+  echo "Domain ${domains[0]} is on certificate."
+else
+  echo "Domain ${domains[0]} did not appear on certificate."
+fi
+
+docker exec "$le_container_name" bash -c "[[ -f /etc/nginx/conf.d/standalone-cert-${domains[0]}.conf ]]" \
+  && echo "Standalone configuration for ${domains[0]} wasn't correctly removed."
+
+# Add another (SAN) certificate to letsencrypt_user_data
+cat > ${TRAVIS_BUILD_DIR}/test/tests/certs_standalone/letsencrypt_user_data <<EOF
+LETSENCRYPT_STANDALONE_CERTS=('single' 'san')
+LETSENCRYPT_single_HOST=('${domains[0]}')
+LETSENCRYPT_san_HOST=('${domains[1]}' '${domains[2]}')
+EOF
+
+# Manually trigger the service loop
+docker exec "$le_container_name" /app/signal_le_service > /dev/null
+
+# Wait for a symlink at /etc/nginx/certs/${domains[1]}.crt
+# then grab the certificate in text form ...
+wait_for_symlink "${domains[1]}" "$le_container_name"
+created_cert="$(docker exec "$le_container_name" \
+  openssl x509 -in /etc/nginx/certs/${domains[1]}/cert.pem -text -noout)"
+
+for domain in "${domains[1]}" "${domains[2]}"; do
+  # Check if the domain is on the certificate.
+  if grep -q "$domain" <<< "$created_cert"; then
+    echo "Domain $domain is on certificate."
+  else
+    echo "Domain $domain did not appear on certificate."
+  fi
+done
+
+docker exec "$le_container_name" bash -c "[[ ! -f /etc/nginx/conf.d/standalone-cert-${domains[1]}.conf ]]" \
+  || echo "Standalone configuration for ${domains[1]} wasn't correctly removed."

--- a/test/tests/certs_standalone_from_env/expected-std-out.txt
+++ b/test/tests/certs_standalone_from_env/expected-std-out.txt
@@ -1,0 +1,67 @@
+Started letsencrypt container for test certs_standalone_from_env
+Started test web server for le1.wtf,le2.wtf,le3.wtf
+Symlink to le1.wtf certificate has been generated.
+The link is pointing to the file ./le1.wtf/fullchain.pem
+le1.wtf is on certificate.
+le2.wtf did not appear on certificate for le1.wtf.
+le3.wtf did not appear on certificate for le1.wtf.
+Connection to le1.wtf using https was successful.
+The correct certificate for le1.wtf was served by Nginx.
+Symlink to le2.wtf certificate has been generated.
+The link is pointing to the file ./le2.wtf/fullchain.pem
+le2.wtf is on certificate.
+le1.wtf did not appear on certificate for le2.wtf.
+le3.wtf did not appear on certificate for le2.wtf.
+Connection to le2.wtf using https was successful.
+The correct certificate for le2.wtf was served by Nginx.
+Symlink to le3.wtf certificate has been generated.
+The link is pointing to the file ./le3.wtf/fullchain.pem
+le3.wtf is on certificate.
+le1.wtf did not appear on certificate for le3.wtf.
+le2.wtf did not appear on certificate for le3.wtf.
+Connection to le3.wtf using https was successful.
+The correct certificate for le3.wtf was served by Nginx.
+Started test web server for le2.wtf, le3.wtf, le1.wtf
+Symlink to le1.wtf certificate has been generated.
+The link is pointing to the file ./le1.wtf/fullchain.pem
+le1.wtf is on certificate.
+le2.wtf did not appear on certificate for le1.wtf.
+le3.wtf did not appear on certificate for le1.wtf.
+Connection to le1.wtf using https was successful.
+The correct certificate for le1.wtf was served by Nginx.
+Symlink to le2.wtf certificate has been generated.
+The link is pointing to the file ./le2.wtf/fullchain.pem
+le2.wtf is on certificate.
+le1.wtf did not appear on certificate for le2.wtf.
+le3.wtf did not appear on certificate for le2.wtf.
+Connection to le2.wtf using https was successful.
+The correct certificate for le2.wtf was served by Nginx.
+Symlink to le3.wtf certificate has been generated.
+The link is pointing to the file ./le3.wtf/fullchain.pem
+le3.wtf is on certificate.
+le1.wtf did not appear on certificate for le3.wtf.
+le2.wtf did not appear on certificate for le3.wtf.
+Connection to le3.wtf using https was successful.
+The correct certificate for le3.wtf was served by Nginx.
+Started test web server for le3.wtf, le1.wtf, le2.wtf,
+Symlink to le1.wtf certificate has been generated.
+The link is pointing to the file ./le1.wtf/fullchain.pem
+le1.wtf is on certificate.
+le2.wtf did not appear on certificate for le1.wtf.
+le3.wtf did not appear on certificate for le1.wtf.
+Connection to le1.wtf using https was successful.
+The correct certificate for le1.wtf was served by Nginx.
+Symlink to le2.wtf certificate has been generated.
+The link is pointing to the file ./le2.wtf/fullchain.pem
+le2.wtf is on certificate.
+le1.wtf did not appear on certificate for le2.wtf.
+le3.wtf did not appear on certificate for le2.wtf.
+Connection to le2.wtf using https was successful.
+The correct certificate for le2.wtf was served by Nginx.
+Symlink to le3.wtf certificate has been generated.
+The link is pointing to the file ./le3.wtf/fullchain.pem
+le3.wtf is on certificate.
+le1.wtf did not appear on certificate for le3.wtf.
+le2.wtf did not appear on certificate for le3.wtf.
+Connection to le3.wtf using https was successful.
+The correct certificate for le3.wtf was served by Nginx.

--- a/test/tests/certs_standalone_from_env/run.sh
+++ b/test/tests/certs_standalone_from_env/run.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+## Test for standalone certificates by NGINX container env variables
+
+if [[ -z $TRAVIS_CI ]]; then
+  le_container_name="$(basename ${0%/*})_$(date "+%Y-%m-%d_%H.%M.%S")"
+else
+  le_container_name="$(basename ${0%/*})"
+fi
+run_le_container ${1:?} "$le_container_name"
+
+# Create the $domains array from comma separated domains in TEST_DOMAINS.
+IFS=',' read -r -a domains <<< "$TEST_DOMAINS"
+
+# Cleanup function with EXIT trap
+function cleanup {
+  # Remove any remaining Nginx container(s) silently.
+  i=1
+  for hosts in "${letsencrypt_hosts[@]}"; do
+    docker rm --force "test$i" > /dev/null 2>&1
+    i=$(( $i + 1 ))
+  done
+  # Cleanup the files created by this run of the test to avoid foiling following test(s).
+  docker exec "$le_container_name" bash -c 'rm -rf /etc/nginx/certs/le?.wtf*'
+  # Stop the LE container
+  docker stop "$le_container_name" > /dev/null
+}
+trap cleanup EXIT
+
+# Create three different comma separated list from the first three domains in $domains.
+# testing for regression on spaced lists https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/issues/288
+# and with trailing comma https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/issues/254
+letsencrypt_hosts=( \
+  [0]="${domains[0]},${domains[1]},${domains[2]}" \     #straight comma separated list
+  [1]="${domains[1]}, ${domains[2]}, ${domains[0]}" \   #comma separated list with spaces
+  [2]="${domains[2]}, ${domains[0]}, ${domains[1]}," )  #comma separated list with spaces and a trailing comma
+
+i=1
+
+for hosts in "${letsencrypt_hosts[@]}"; do
+
+  # Get the base domain (first domain of the list).
+  base_domain="$(get_base_domain "$hosts")"
+  container="test$i"
+
+  # Run an Nginx container passing one of the comma separated list as LETSENCRYPT_HOST env var.
+  docker run --rm -d \
+    --name "$container" \
+    -e "VIRTUAL_HOST=${TEST_DOMAINS}" \
+    -e "LETSENCRYPT_HOST=${hosts}" \
+    -e "LETSENCRYPT_STANDALONE_CERTS=true" \
+    --network boulder_bluenet \
+    nginx:alpine > /dev/null && echo "Started test web server for $hosts"
+
+  for domain in "${domains[@]}"; do
+      ## For all the domains in the $domains array ...
+      wait_for_symlink "${domain}" "$le_container_name"
+      created_cert="$(docker exec "$le_container_name" \
+        openssl x509 -in /etc/nginx/certs/${domain}/cert.pem -text -noout)"
+      # ... as well as the certificate fingerprint.
+      created_cert_fingerprint="$(docker exec "$le_container_name" \
+        sh -c "openssl x509 -in "/etc/nginx/certs/${domain}/cert.pem" -fingerprint -noout")"
+
+    # Check if the domain is on the certificate.
+    if grep -q "$domain" <<< "$created_cert"; then
+      echo "$domain is on certificate."
+      for otherdomain in "${domains[@]}"; do
+        if [ "$domain" != "$otherdomain" ]; then
+          if grep -q "$otherdomain" <<< "$created_cert"; then
+            echo "$otherdomain is on certificate for $domain, but it must not!"
+          else
+            echo "$otherdomain did not appear on certificate for $domain."
+          fi
+        fi
+      done
+    else
+      echo "$domain did not appear on certificate."
+    fi
+
+    # Wait for a connection to https://domain then grab the served certificate in text form.
+    wait_for_conn --domain "$domain"
+    served_cert_fingerprint="$(echo \
+      | openssl s_client -showcerts -servername $domain -connect $domain:443 2>/dev/null \
+      | openssl x509 -fingerprint -noout)"
+
+
+    # Compare the cert on file and what we got from the https connection.
+    # If not identical, display a full diff.
+    if [ "$created_cert_fingerprint" != "$served_cert_fingerprint" ]; then
+      echo "Nginx served an incorrect certificate for $domain."
+      served_cert="$(echo \
+        | openssl s_client -showcerts -servername "$domain" -connect "$domain:443" 2>/dev/null \
+        | openssl x509 -text -noout \
+        | sed 's/ = /=/g' )"
+      diff -u <(echo "$created_cert" | sed 's/ = /=/g') <(echo "$served_cert")
+    else
+      echo "The correct certificate for $domain was served by Nginx."
+    fi
+  done
+
+  docker stop "$container" > /dev/null 2>&1
+  docker exec "$le_container_name" bash -c 'rm -rf /etc/nginx/certs/le?.wtf*'
+  i=$(( $i + 1 ))
+
+done


### PR DESCRIPTION
Hi, @buchdag 

I've followed your idea with LETSENCRYPT_STANDALONE_CERTS and ported it to environment variables of Nginx container.

The usage will be pretty simple:

docker-compose.yml

```
version: '3'

services:
  nginx:
    image: nginx:latest
    environment:
      - "LETSENCRYPT_STANDALONE_CERTS=true"
      - "VIRTUAL_HOST=example.com,private.acme.com,dev.acme.com"
      - "LETSENCRYPT_HOST=example.com,private.acme.com,dev.acme.com"
```

This config will produce three separate certificates. It seems more correct in terms of decoupling to claim separate certificates from the Nginx container env, than touching the main LE companion.

If the PR is acceptable, I will adjust the documentations