### PR TITLE
Implemented segregation by network

### DIFF
--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -5,9 +5,9 @@
     {{ if trim $hosts }}
         {{ range $container := $containers }}
             {{ $cid := printf "%.12s" $container.ID }}
-            {{ if $CurrentContainer.Env.MUST_BE_CONNECTED_WITH_NETWORK }}
+            {{ if $CurrentContainer.Env.NETWORK_SCOPE }}
                 {{ range $containerNetwork := $container.Networks }}
-                    {{ if eq $CurrentContainer.Env.MUST_BE_CONNECTED_WITH_NETWORK $containerNetwork.Name }}
+                    {{ if eq $CurrentContainer.Env.NETWORK_SCOPE $containerNetwork.Name }}
                         {{ $scopedContainersString = (printf "%s %s" $scopedContainersString $cid) }}
                     {{ end }}
                 {{ end }}

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -1,14 +1,38 @@
+{{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
+{{ $scopedContainersString := "" }}
+
+{{ range $hosts, $containers := groupBy $ "Env.LETSENCRYPT_HOST" }}
+    {{ if trim $hosts }}
+        {{ range $container := $containers }}
+            {{ $cid := printf "%.12s" $container.ID }}
+            {{ if $CurrentContainer.Env.MUST_BE_CONNECTED_WITH_NETWORK }}
+                {{ range $containerNetwork := $container.Networks }}
+                    {{ if eq $CurrentContainer.Env.MUST_BE_CONNECTED_WITH_NETWORK $containerNetwork.Name }}
+                        {{ $scopedContainersString = (printf "%s %s" $scopedContainersString $cid) }}
+                    {{ end }}
+                {{ end }}
+            {{ else }}
+                {{ $scopedContainersString = (printf "%s %s" $scopedContainersString $cid) }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+
+{{ $scopedContainersSlice := split (trim $scopedContainersString) " " }}
+
 LETSENCRYPT_CONTAINERS=(
     {{ range $hosts, $containers := groupBy $ "Env.LETSENCRYPT_HOST" }}
         {{ if trim $hosts }}
             {{ range $container := $containers }}
-                {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
-                    {{ range $host := split $hosts "," }}
-                        {{ $host := trim $host }}
-                        '{{ printf "%.12s" $container.ID }}_{{ sha1 $host }}'
+                {{ $cid := printf "%.12s" $container.ID }}
+                {{ if intersect $scopedContainersSlice (split $cid " ") }}
+                    {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
+                        {{ range $host := split $hosts "," }}
+                            '{{ printf "%s_%s" $cid (sha1 (trim $host)) }}'
+                        {{ end }}
+                    {{ else }}
+                        '{{ $cid }}'
                     {{ end }}
-                {{ else }}
-                    '{{ printf "%.12s" $container.ID }}'
                 {{ end }}
             {{ end }}
         {{ end }}
@@ -19,26 +43,28 @@ LETSENCRYPT_CONTAINERS=(
     {{ $hosts := trimSuffix "," $hosts }}
     {{ range $container := $containers }}
         {{ $cid := printf "%.12s" $container.ID }}
-        {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
-            {{ range $host := split $hosts "," }}
-                {{ $host := trim $host }}
-                {{ $hostHash := sha1 $host }}
-                LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_HOST=('{{ $host }}')
-                LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_EMAIL="{{ $container.Env.LETSENCRYPT_EMAIL }}"
-                LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_KEYSIZE="{{ $container.Env.LETSENCRYPT_KEYSIZE }}"
-                LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_TEST="{{ $container.Env.LETSENCRYPT_TEST }}"
-                LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_ACCOUNT_ALIAS="{{ $container.Env.LETSENCRYPT_ACCOUNT_ALIAS }}"
-                LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_RESTART_CONTAINER="{{ $container.Env.LETSENCRYPT_RESTART_CONTAINER }}"
-                LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_MIN_VALIDITY="{{ $container.Env.LETSENCRYPT_MIN_VALIDITY }}"
+        {{ if intersect $scopedContainersSlice (split $cid " ") }}
+            {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
+                {{ range $host := split $hosts "," }}
+                    {{ $host := trim $host }}
+                    {{ $hostHash := sha1 $host }}
+                    LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_HOST=('{{ $host }}')
+                    LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_EMAIL="{{ $container.Env.LETSENCRYPT_EMAIL }}"
+                    LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_KEYSIZE="{{ $container.Env.LETSENCRYPT_KEYSIZE }}"
+                    LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_TEST="{{ $container.Env.LETSENCRYPT_TEST }}"
+                    LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_ACCOUNT_ALIAS="{{ $container.Env.LETSENCRYPT_ACCOUNT_ALIAS }}"
+                    LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_RESTART_CONTAINER="{{ $container.Env.LETSENCRYPT_RESTART_CONTAINER }}"
+                    LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_MIN_VALIDITY="{{ $container.Env.LETSENCRYPT_MIN_VALIDITY }}"
+                {{ end }}
+            {{ else }}
+                LETSENCRYPT_{{ $cid }}_HOST=( {{ range $host := split $hosts "," }}{{ $host := trim $host }}'{{ $host }}' {{ end }})
+                LETSENCRYPT_{{ $cid }}_EMAIL="{{ $container.Env.LETSENCRYPT_EMAIL }}"
+                LETSENCRYPT_{{ $cid }}_KEYSIZE="{{ $container.Env.LETSENCRYPT_KEYSIZE }}"
+                LETSENCRYPT_{{ $cid }}_TEST="{{ $container.Env.LETSENCRYPT_TEST }}"
+                LETSENCRYPT_{{ $cid }}_ACCOUNT_ALIAS="{{ $container.Env.LETSENCRYPT_ACCOUNT_ALIAS }}"
+                LETSENCRYPT_{{ $cid }}_RESTART_CONTAINER="{{ $container.Env.LETSENCRYPT_RESTART_CONTAINER }}"
+                LETSENCRYPT_{{ $cid }}_MIN_VALIDITY="{{ $container.Env.LETSENCRYPT_MIN_VALIDITY }}"
             {{ end }}
-        {{ else }}
-            LETSENCRYPT_{{ $cid }}_HOST=( {{ range $host := split $hosts "," }}{{ $host := trim $host }}'{{ $host }}' {{ end }})
-            LETSENCRYPT_{{ $cid }}_EMAIL="{{ $container.Env.LETSENCRYPT_EMAIL }}"
-            LETSENCRYPT_{{ $cid }}_KEYSIZE="{{ $container.Env.LETSENCRYPT_KEYSIZE }}"
-            LETSENCRYPT_{{ $cid }}_TEST="{{ $container.Env.LETSENCRYPT_TEST }}"
-            LETSENCRYPT_{{ $cid }}_ACCOUNT_ALIAS="{{ $container.Env.LETSENCRYPT_ACCOUNT_ALIAS }}"
-            LETSENCRYPT_{{ $cid }}_RESTART_CONTAINER="{{ $container.Env.LETSENCRYPT_RESTART_CONTAINER }}"
-            LETSENCRYPT_{{ $cid }}_MIN_VALIDITY="{{ $container.Env.LETSENCRYPT_MIN_VALIDITY }}"
         {{ end }}
     {{ end }}
 {{ end }}

--- a/test/config.sh
+++ b/test/config.sh
@@ -20,5 +20,6 @@ imageTests+=(
 	permissions_default
 	permissions_custom
 	symlinks
+	networks_segregation
 	'
 )

--- a/test/tests/networks_segregation/expected-std-out.txt
+++ b/test/tests/networks_segregation/expected-std-out.txt
@@ -1,0 +1,11 @@
+Started letsencrypt container for test networks_segregation
+Started test web server for le1.wtf in net boulder_bluenet
+Started test web server for le2.wtf in net le_test_other_net1
+Started test web server for le3.wtf in net le_test_other_net2
+le1.wtf is in boulder_bluenet, cert should be generated
+Symlink to le1.wtf certificate has been generated.
+The link is pointing to the file ./le1.wtf/fullchain.pem
+le2.wtf is not in boulder_bluenet, cert should not be generated
+Domain le2.wtf was not included in the service_data.
+le3.wtf is not in boulder_bluenet, cert should not be generated
+Domain le3.wtf was not included in the service_data.

--- a/test/tests/networks_segregation/run.sh
+++ b/test/tests/networks_segregation/run.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+## Test for single domain certificates.
+
+if [[ -z $TRAVIS ]]; then
+  le_container_name="$(basename ${0%/*})_$(date "+%Y-%m-%d_%H.%M.%S")"
+else
+  le_container_name="$(basename ${0%/*})"
+fi
+desired_network="boulder_bluenet"
+run_le_container ${1:?} "$le_container_name" "--env MUST_BE_CONNECTED_WITH_NETWORK=$desired_network"
+
+# Create the $domains array from comma separated domains in TEST_DOMAINS.
+IFS=',' read -r -a domains <<< "$TEST_DOMAINS"
+
+# Cleanup function with EXIT trap
+function cleanup {
+  # Remove any remaining Nginx container(s) silently.
+  for domain in "${domains[@]}"; do
+    docker rm --force "$domain" > /dev/null 2>&1
+  done
+  # Cleanup the files created by this run of the test to avoid foiling following test(s).
+  docker exec "$le_container_name" bash -c 'rm -rf /etc/nginx/certs/le?.wtf*'
+  # Stop the LE container
+  docker stop "$le_container_name" > /dev/null
+  # Drop temp network
+  docker network rm "le_test_other_net1" > /dev/null
+  docker network rm "le_test_other_net2" > /dev/null
+}
+trap cleanup EXIT
+
+docker network create "le_test_other_net1" > /dev/null
+docker network create "le_test_other_net2" > /dev/null
+
+networks_map=("$desired_network" le_test_other_net1 le_test_other_net2)
+
+# Run a separate nginx container for each domain in the $domains array.
+# Start all the containers in a row so that docker-gen debounce timers fire only once.
+i=0
+for domain in "${domains[@]}"; do
+  docker run --rm -d \
+    --name "$domain" \
+    -e "VIRTUAL_HOST=${domain}" \
+    -e "LETSENCRYPT_HOST=${domain}" \
+    --network "${networks_map[i]}" \
+    nginx:alpine > /dev/null && echo "Started test web server for $domain in net ${networks_map[${i}]}"
+
+  i=$(( $i + 1 ))
+done
+
+i=0
+for domain in "${domains[@]}"; do
+  if [ "${networks_map[i]}" != "$desired_network" ]; then
+     echo "$domain is not in $desired_network, cert should not be generated";
+
+     service_data="$(docker exec "$le_container_name" cat /app/letsencrypt_service_data)"
+     if grep -q "$domain" <<< "$service_data"; then
+       echo "Domain $domain is on data list, but MUST not!"
+     else
+       echo "Domain $domain was not included in the service_data."
+     fi
+  else
+      echo "$domain is in $desired_network, cert should be generated";
+
+      # Wait for a symlink at /etc/nginx/certs/$domain.crt
+      wait_for_symlink "$domain" "$le_container_name"
+  fi
+  # Stop the Nginx container silently.
+  docker stop "$domain" > /dev/null
+  i=$(( $i + 1 ))
+done

--- a/test/tests/networks_segregation/run.sh
+++ b/test/tests/networks_segregation/run.sh
@@ -8,7 +8,7 @@ else
   le_container_name="$(basename ${0%/*})"
 fi
 desired_network="boulder_bluenet"
-run_le_container ${1:?} "$le_container_name" "--env MUST_BE_CONNECTED_WITH_NETWORK=$desired_network"
+run_le_container ${1:?} "$le_container_name" "--env NETWORK_SCOPE=$desired_network"
 
 # Create the $domains array from comma separated domains in TEST_DOMAINS.
 IFS=',' read -r -a domains <<< "$TEST_DOMAINS"


### PR DESCRIPTION
Hi, @buchdag!

This pull-request implements the discussion we've started in #571

I've introduced a new env variable for LE container `MUST_BE_CONNECTED_WITH_NETWORK`, that limits the LE scope to containers, included only in the specified network. The tests are included.

Could you review this pull request, please? If it seems acceptable to you, I will add the necessary documentation. Thank you!