### PR TITLE
Remove deprecated keys / aliases from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 os: linux
 dist: trusty
-sudo: required
 
-language: bash
+language: shell
 
 addons:
   hosts:
@@ -18,25 +17,21 @@ env:
     - TEST_DOMAINS=le1.wtf,le2.wtf,le3.wtf
     - DOCKER_COMPOSE_VERSION=1.24.0
 
-matrix:
+jobs:
   include:
     - env: SETUP=2containers
     - env: SETUP=3containers
     - os: linux
       dist: xenial
-      sudo: required
       env: SETUP=2containers
     - os: linux
       dist: xenial
-      sudo: required
       env: SETUP=3containers
     - os: linux
       dist: bionic
-      sudo: required
       env: SETUP=2containers
     - os: linux
       dist: bionic
-      sudo: required
       env: SETUP=3containers
   allow_failures:
     - dist: bionic


### PR DESCRIPTION
This PR fixes Travis Build config validation's warning and informations.

![travis-config](https://user-images.githubusercontent.com/13685826/76219724-8d70bd80-6216-11ea-9590-841c363d77a7.jpg)
