### PR TITLE
Update simp_le to 0.18.0

### DIFF
--- a/install_simp_le.sh
+++ b/install_simp_le.sh
@@ -10,7 +10,7 @@ apk add --update python3 git gcc musl-dev libffi-dev python3-dev openssl-dev
 [[ -e /usr/bin/python ]] || ln -sf /usr/bin/python3 /usr/bin/python
 
 # Get Let's Encrypt simp_le client source
-branch="0.16.0"
+branch="0.18.0"
 mkdir -p /src
 git -C /src clone --depth=1 --branch $branch https://github.com/zenhack/simp_le.git
 


### PR DESCRIPTION
Updated simp_le tagged version to include fix for Buypass CA. Fixes issue https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/issues/634