### PR TITLE
Travis CI is no longer free for OSS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: trusty
+dist: focal
 
 language: shell
 
@@ -21,21 +21,6 @@ jobs:
   include:
     - env: SETUP=2containers
     - env: SETUP=3containers
-    - os: linux
-      dist: xenial
-      env: SETUP=2containers
-    - os: linux
-      dist: xenial
-      env: SETUP=3containers
-    - os: linux
-      dist: bionic
-      env: SETUP=2containers
-    - os: linux
-      dist: bionic
-      env: SETUP=3containers
-  allow_failures:
-    - dist: bionic
-  fast_finish: true
 
 before_install:
   - test/travis/update-docker-compose.sh


### PR DESCRIPTION
Travis CI changed its pricing model, OSS builds are no longer free: https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing

This commit greatly reduce credit consumption by building only on one Linux distro (Ubuntu 20.04), instead of three previously.

The next move will either be obtaining free monthly credit from Travis CI or moving to GitHub actions.