### PR TITLE
Speed up tests execution.

### DIFF
--- a/app/start.sh
+++ b/app/start.sh
@@ -18,7 +18,9 @@ trap 'term_handler' INT QUIT TERM
 /app/letsencrypt_service &
 letsencrypt_service_pid=$!
 
-docker-gen -watch -notify '/app/signal_le_service' -wait 15s:60s /app/letsencrypt_service_data.tmpl /app/letsencrypt_service_data &
+wait_default="500ms:2s"
+DOCKER_GEN_WAIT="${DOCKER_GEN_WAIT:-$wait_default}"
+docker-gen -watch -notify '/app/signal_le_service' -wait "$DOCKER_GEN_WAIT" /app/letsencrypt_service_data.tmpl /app/letsencrypt_service_data &
 docker_gen_pid=$!
 
 # wait "indefinitely"

--- a/test/setup/setup-nginx-proxy.sh
+++ b/test/setup/setup-nginx-proxy.sh
@@ -38,7 +38,7 @@ case $SETUP in
       --label com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite \
       --network boulder_bluenet \
       jwilder/docker-gen \
-      -notify-sighup $NGINX_CONTAINER_NAME -watch -wait 5s:30s /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+      -notify-sighup $NGINX_CONTAINER_NAME -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
     ;;
 
   *)

--- a/test/tests/container_restart/run.sh
+++ b/test/tests/container_restart/run.sh
@@ -50,19 +50,14 @@ done
 for domain in "${domains[@]}"; do
 
   # Check if container restarted
-  i=0
-  until grep "$domain" ${TRAVIS_BUILD_DIR}/test/tests/container_restart/docker_event_out.txt; do
-    if [ "$waited_once" = true ]; then
+  timeout="$(date +%s)"
+  timeout="$((timeout + 60))"
+  until grep "$domain" "${TRAVIS_BUILD_DIR}"/test/tests/container_restart/docker_event_out.txt; do
+    if [[ "$(date +%s)" -gt "$timeout" ]]; then
       echo "Container $domain didn't restart in under one minute."
-      break
-    elif [ $i -gt 60 ]; then
-      echo "Container $domain didn't restart in under one minute."
-      # Wait only once for all containers (since all containers are started together)
-      waited_once=true
       break
     fi
-    i=$((i + 2))
-    sleep 2
+    sleep 0.1
   done
   
   # Stop the Nginx container silently.


### PR DESCRIPTION
This PR does two things motsly aimed at speeding up tests:

- It makes `docker-gen`'s `--wait` argument user configurable via an environment variable (`DOCKER_GEN_WAIT`) and lower the default from a **minimum wait of 15 seconds** after container change events to a more reasonable 500 milliseconds. `--wait` was only supposed to act as debounce, and 15 seconds is pretty long for a debounce.
- It uses more agressive polling in the tests and fix the timeouts so that they're based on real elapsed time and not on the number of iterations through the loop.

This saves roughly another 20% of build time on Travis CI.