### PR TITLE
Remove default volumes from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,5 @@ COPY /app/ /app/
 
 WORKDIR /app
 
-VOLUME ["/etc/acme.sh", "/etc/nginx/certs"]
-
 ENTRYPOINT [ "/bin/bash", "/app/entrypoint.sh" ]
 CMD [ "/bin/bash", "/app/start.sh" ]


### PR DESCRIPTION
The volumes on the Dockerfile were parts of my early work on the transition to `amce.sh` and should not have made their way in #719 as they prevent detection of missing volumes by the `check_writable_directory()` tests in the entrypoint script.