### PR TITLE
Fix unintentional file globbing during wildcard lookup

### DIFF
--- a/app/cleanup_test_artifacts
+++ b/app/cleanup_test_artifacts
@@ -16,8 +16,8 @@ while [[ $# -gt 0 ]]; do
         ;;
 
         --location-config)
-        for filepath in '/etc/nginx/vhost.d/le1.wtf' '/etc/nginx/vhost.d/*.example.com' '/etc/nginx/vhost.d/test.*'; do
-            [[ -f "$filepath" ]] && rm -rf "$filepath"
+        for domain in 'le1.wtf' '*.example.com' 'test.*' 'le3.pizza' 'subdomain.example.com' 'test.domain.tld'; do
+            [[ -f "/etc/nginx/vhost.d/$domain" ]] && rm -f "/etc/nginx/vhost.d/$domain"
         done
         shift
         ;;

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -79,13 +79,13 @@ function add_location_configuration {
     # If the domain does not have an exact matching location file, test the possible
     # wildcard locations files. Use default is no location file is present at all.
     if [[ ! -f "${VHOST_DIR}/${domain}" ]]; then
-      for wildcard_domain in $(enumerate_wildcard_locations "$domain"); do
+      while read -r wildcard_domain; do
         if [[ -f "${VHOST_DIR}/${wildcard_domain}" ]]; then
           domain="$wildcard_domain"
           break
         fi
         domain='default'
-      done
+      done <<< "$(enumerate_wildcard_locations "$domain")"
     fi
 
     if [[ -f "${VHOST_DIR}/${domain}" && -n $(sed -n "/$START_HEADER/,/$END_HEADER/p" "${VHOST_DIR}/${domain}") ]]; then

--- a/test/tests/location_config/run.sh
+++ b/test/tests/location_config/run.sh
@@ -150,6 +150,10 @@ for domain in "${domains[@]:0:2}" '*.example.com' 'test.*'; do
   fi
 done
 
+# Should not be used by anything, but potentially matches an enumerate_wildcard_locations file glob.
+docker exec "$NGINX_CONTAINER_NAME" touch /etc/nginx/vhost.d/le3.pizza
+docker exec "$le_container_name" touch le3.pizza
+
 # Trying to add location configuration to non existing le3.wtf should only configure default
 docker exec "$le_container_name" bash -c "source /app/functions.sh; add_location_configuration ${domains[2]}"
 
@@ -161,8 +165,7 @@ if docker exec "$le_container_name" [ -e "$config_path" ]; then
 fi
 
 config_path="$vhost_path/default"
-docker exec "$le_container_name" bash -c 'source /app/functions.sh; add_location_configuration'
 if ! check_location "$le_container_name" "$config_path" ; then
-  echo "Unexpected location configuration on $config_path after call to remove_all_location_configurations ${domains[2]}:"
+  echo "Unexpected location configuration on $config_path after call to add_location_configuration ${domains[2]}:"
   docker exec "$le_container_name" cat "$config_path"
 fi


### PR DESCRIPTION
Matching globs are common because the script runs in the certs
directory.

The test uses a suffix match as the test domains don't include
subdomains, although such cases should probably be considered.

Fix the le3.wtf test. The existing add_location_configuration modifies
"default"; a second add is not necessary.

Fixes #763